### PR TITLE
Consolidate Arel's definitions of impossibile and tautological conditions

### DIFF
--- a/activerecord/lib/active_record/relation/query_methods.rb
+++ b/activerecord/lib/active_record/relation/query_methods.rb
@@ -1071,7 +1071,7 @@ module ActiveRecord
     end
 
     def none! # :nodoc:
-      where!("1=0").extending!(NullRelation)
+      where!(Arel::Nodes::Impossibility.new).extending!(NullRelation)
     end
 
     # Mark a relation as readonly. Attempting to update a record will result in

--- a/activerecord/lib/arel/nodes.rb
+++ b/activerecord/lib/arel/nodes.rb
@@ -14,6 +14,8 @@ require "arel/nodes/bind_param"
 require "arel/nodes/terminal"
 require "arel/nodes/true"
 require "arel/nodes/false"
+require "arel/nodes/impossibility"
+require "arel/nodes/tautology"
 
 # unary
 require "arel/nodes/unary"

--- a/activerecord/lib/arel/nodes/impossibility.rb
+++ b/activerecord/lib/arel/nodes/impossibility.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class Impossibility < Arel::Nodes::NodeExpression
+      def hash
+        self.class.hash
+      end
+
+      def eql?(other)
+        self.class == other.class
+      end
+      alias :== :eql?
+    end
+  end
+end

--- a/activerecord/lib/arel/nodes/tautology.rb
+++ b/activerecord/lib/arel/nodes/tautology.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Arel # :nodoc: all
+  module Nodes
+    class Tautology < Arel::Nodes::NodeExpression
+      def hash
+        self.class.hash
+      end
+
+      def eql?(other)
+        self.class == other.class
+      end
+      alias :== :eql?
+    end
+  end
+end

--- a/activerecord/lib/arel/visitors/to_sql.rb
+++ b/activerecord/lib/arel/visitors/to_sql.rb
@@ -86,6 +86,14 @@ module Arel # :nodoc: all
         end
         alias :visit_Arel_Nodes_Quoted :visit_Arel_Nodes_Casted
 
+        def visit_Arel_Nodes_Tautology(o, collector)
+          collector << "1=1"
+        end
+
+        def visit_Arel_Nodes_Impossibility(o, collector)
+          collector << "1=0"
+        end
+
         def visit_Arel_Nodes_True(o, collector)
           collector << "TRUE"
         end
@@ -434,9 +442,9 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_GreaterThanOrEqual(o, collector)
           case unboundable?(o.right)
           when 1
-            return collector << "1=0"
+            return visit_Arel_Nodes_Impossibility(o, collector)
           when -1
-            return collector << "1=1"
+            return visit_Arel_Nodes_Tautology(o, collector)
           end
           collector = visit o.left, collector
           collector << " >= "
@@ -446,9 +454,9 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_GreaterThan(o, collector)
           case unboundable?(o.right)
           when 1
-            return collector << "1=0"
+            return visit_Arel_Nodes_Impossibility(o, collector)
           when -1
-            return collector << "1=1"
+            return visit_Arel_Nodes_Tautology(o, collector)
           end
           collector = visit o.left, collector
           collector << " > "
@@ -458,9 +466,9 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_LessThanOrEqual(o, collector)
           case unboundable?(o.right)
           when 1
-            return collector << "1=1"
+            return visit_Arel_Nodes_Tautology(o, collector)
           when -1
-            return collector << "1=0"
+            return visit_Arel_Nodes_Impossibility(o, collector)
           end
           collector = visit o.left, collector
           collector << " <= "
@@ -470,9 +478,9 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_LessThan(o, collector)
           case unboundable?(o.right)
           when 1
-            return collector << "1=1"
+            return visit_Arel_Nodes_Tautology(o, collector)
           when -1
-            return collector << "1=0"
+            return visit_Arel_Nodes_Impossibility(o, collector)
           end
           collector = visit o.left, collector
           collector << " < "
@@ -585,7 +593,7 @@ module Arel # :nodoc: all
               values.delete_if { |value| unboundable?(value) }
             end
 
-            return collector << "1=0" if values.empty?
+            return visit_Arel_Nodes_Impossibility(o, collector) if values.empty?
           end
 
           visit(attr, collector) << " IN ("
@@ -601,7 +609,7 @@ module Arel # :nodoc: all
               values.delete_if { |value| unboundable?(value) }
             end
 
-            return collector << "1=1" if values.empty?
+            return visit_Arel_Nodes_Tautology(o, collector) if values.empty?
           end
 
           visit(attr, collector) << " NOT IN ("
@@ -643,7 +651,7 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_Equality(o, collector)
           right = o.right
 
-          return collector << "1=0" if unboundable?(right)
+          return visit_Arel_Nodes_Impossibility(o, collector) if unboundable?(right)
 
           collector = visit o.left, collector
 
@@ -678,7 +686,7 @@ module Arel # :nodoc: all
         def visit_Arel_Nodes_NotEqual(o, collector)
           right = o.right
 
-          return collector << "1=1" if unboundable?(right)
+          return visit_Arel_Nodes_Tautology(o, collector) if unboundable?(right)
 
           collector = visit o.left, collector
 


### PR DESCRIPTION
Beyond reducing the number of instances of "1=0" strings, this incidentally fixes `none.to_sql == where(id: []).to_sql` (and by extension, the Relation#== equivalent), where they previously differed by unnecessary parens.

cc @codeminator