### PR TITLE
Fix issues with idle_timeout in connection_pool_test

### DIFF
--- a/activerecord/CHANGELOG.md
+++ b/activerecord/CHANGELOG.md
@@ -1,3 +1,11 @@
+*   Introduce new database configuration options `keepalive`, `max_age`, and
+    `min_connections` -- and rename `pool` to `max_connections` to match.
+
+    There are no changes to default behavior, but these allow for more specific
+    control over pool behavior.
+
+    *Matthew Draper*, *Chris AtLee*, *Rachael Wright-Munn*
+
 *   Fix using the `SQLite3Adapter`'s `dbconsole` method outside of a Rails application.
 
     *Hartley McGuire*

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -771,6 +771,21 @@ module ActiveRecord
         end
       end
 
+      # Immediately mark all current connections as due for replacement,
+      # equivalent to them having reached +max_age+ -- even if there is
+      # no +max_age+ configured.
+      def recycle!
+        synchronize do
+          return if self.discarded?
+
+          @connections.each do |conn|
+            conn.force_retirement
+          end
+        end
+
+        retire_old_connections
+      end
+
       def num_waiting_in_queue # :nodoc:
         @available.num_waiting
       end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -281,6 +281,7 @@ module ActiveRecord
         @schema_cache = nil
 
         @activated = false
+        @original_context = ActiveSupport::IsolatedExecutionState.context
 
         @reaper = Reaper.new(self, db_config.reaping_frequency)
         @reaper.run
@@ -702,7 +703,7 @@ module ActiveRecord
 
       # Disconnect all currently idle connections. Connections currently checked
       # out are unaffected. The pool will stop maintaining its minimum size until
-      # it is reactivated.
+      # it is reactivated (such as by a subsequent checkout).
       def flush!
         reap
         flush(-1)
@@ -1089,6 +1090,10 @@ module ActiveRecord
           # constraint
           do_checkout = synchronize do
             if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_size && (!block_given? || yield)
+              if @connections.size > 0 || @original_context != ActiveSupport::IsolatedExecutionState.context
+                @activated = true
+              end
+
               @now_connecting += 1
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -280,6 +280,8 @@ module ActiveRecord
 
         @schema_cache = nil
 
+        @activated = false
+
         @reaper = Reaper.new(self, db_config.reaping_frequency)
         @reaper.run
       end
@@ -314,6 +316,14 @@ module ActiveRecord
 
       def internal_metadata # :nodoc:
         InternalMetadata.new(self)
+      end
+
+      def activate
+        @activated = true
+      end
+
+      def activated?
+        @activated
       end
 
       # Retrieve the connection associated with the current thread, or call
@@ -691,10 +701,30 @@ module ActiveRecord
       end
 
       # Disconnect all currently idle connections. Connections currently checked
-      # out are unaffected.
+      # out are unaffected. The pool will stop maintaining its minimum size until
+      # it is reactivated.
       def flush!
         reap
         flush(-1)
+
+        # Stop maintaining the minimum size until reactivated
+        @activated = false
+      end
+
+      # Ensure that the pool contains at least the configured minimum number of
+      # connections.
+      def prepopulate
+        return if self.discarded?
+
+        # We don't want to start prepopulating until we know the pool is wanted,
+        # so we can avoid maintaining full pools in one-off scripts etc.
+        return unless @activated
+
+        if @connections.size < @min_size
+          while new_conn = try_to_checkout_new_connection { @connections.size < @min_size }
+            checkin(new_conn)
+          end
+        end
       end
 
       def num_waiting_in_queue # :nodoc:
@@ -1047,6 +1077,9 @@ module ActiveRecord
 
         # If the pool is not at a <tt>@max_size</tt> limit, establish new connection. Connecting
         # to the DB is done outside main synchronized section.
+        #
+        # If a block is supplied, it is an additional constraint (checked while holding the
+        # pool lock) on whether a new connection should be established.
         #--
         # Implementation constraint: a newly established connection returned by this
         # method must be in the +.leased+ state.
@@ -1055,7 +1088,7 @@ module ActiveRecord
           # and increment @now_connecting, to prevent overstepping this pool's @max_size
           # constraint
           do_checkout = synchronize do
-            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_size
+            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_size && (!block_given? || yield)
               @now_connecting += 1
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -112,6 +112,8 @@ module ActiveRecord
     #   exist before retiring it at next checkin. (default Float::INFINITY).
     # * +max_connections+: maximum number of connections the pool may manage (default 5).
     # * +min_connections+: minimum number of connections the pool will open and maintain (default 0).
+    # * +pool_jitter+: maximum reduction factor to apply to +max_age+ and
+    #   +keepalive+ intervals (default 0.2; range 0.0-1.0).
     #
     #--
     # Synchronization policy:
@@ -738,7 +740,7 @@ module ActiveRecord
       def retire_old_connections(max_age = @max_age)
         max_age ||= Float::INFINITY
 
-        sequential_maintenance -> c { c.connection_age&.>= max_age } do |conn|
+        sequential_maintenance -> c { c.connection_age&.>= c.pool_jitter(max_age) } do |conn|
           # Disconnect, then return the adapter to the pool. Preconnect will
           # handle the rest.
           conn.disconnect!
@@ -766,7 +768,7 @@ module ActiveRecord
       def keep_alive(threshold = @keepalive)
         return if threshold.nil?
 
-        sequential_maintenance -> c { (c.seconds_since_last_activity || 0) > threshold } do |conn|
+        sequential_maintenance -> c { (c.seconds_since_last_activity || 0) > c.pool_jitter(threshold) } do |conn|
           # conn.active? will cause some amount of network activity, which is all
           # we need to provide a keepalive signal.
           #

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -220,7 +220,8 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :size, :reaper, :pool_config, :async_executor, :role, :shard
+      attr_reader :db_config, :max_size, :min_size, :reaper, :pool_config, :async_executor, :role, :shard
+      alias :size :max_size
 
       delegate :schema_reflection, :server_version, to: :pool_config
 
@@ -240,7 +241,8 @@ module ActiveRecord
 
         @checkout_timeout = db_config.checkout_timeout
         @idle_timeout = db_config.idle_timeout
-        @size = db_config.pool
+        @max_size = db_config.pool
+        @min_size = db_config.min_size
 
         # This variable tracks the cache of threads mapped to reserved connections, with the
         # sole purpose of speeding up the +connection+ method. It is not the authoritative
@@ -607,7 +609,7 @@ module ActiveRecord
           @available.delete conn
 
           # @available.any_waiting? => true means that prior to removing this
-          # conn, the pool was at its max size (@connections.size == @size).
+          # conn, the pool was at its max size (@connections.size == @max_size).
           # This would mean that any threads stuck waiting in the queue wouldn't
           # know they could checkout_new_connection, so let's do it for them.
           # Because condition-wait loop is encapsulated in the Queue class
@@ -622,7 +624,7 @@ module ActiveRecord
         # would like not to hold the main mutex while checking out new connections.
         # Thus there is some chance that needs_new_connection information is now
         # stale, we can live with that (bulk_make_new_connections will make
-        # sure not to exceed the pool's @size limit).
+        # sure not to exceed the pool's @max_size limit).
         bulk_make_new_connections(1) if needs_new_connection
       end
 
@@ -655,11 +657,27 @@ module ActiveRecord
       def flush(minimum_idle = @idle_timeout)
         return if minimum_idle.nil?
 
-        idle_connections = synchronize do
+        removed_connections = synchronize do
           return if self.discarded?
-          @connections.select do |conn|
+
+          idle_connections = @connections.select do |conn|
             !conn.in_use? && conn.seconds_idle >= minimum_idle
-          end.each do |conn|
+          end.sort_by { |conn| -conn.seconds_idle } # sort longest idle first
+
+          # Don't go below our configured pool minimum unless we're flushing
+          # everything
+          idles_to_retain =
+            if minimum_idle > 0
+              @min_size - (@connections.size - idle_connections.size)
+            else
+              0
+            end
+
+          if idles_to_retain > 0
+            idle_connections.pop idles_to_retain
+          end
+
+          idle_connections.each do |conn|
             conn.lease
 
             @available.delete conn
@@ -667,7 +685,7 @@ module ActiveRecord
           end
         end
 
-        idle_connections.each do |conn|
+        removed_connections.each do |conn|
           conn.disconnect!
         end
       end
@@ -842,7 +860,7 @@ module ActiveRecord
         # this is unfortunately not concurrent
         def bulk_make_new_connections(num_new_conns_needed)
           num_new_conns_needed.times do
-            # try_to_checkout_new_connection will not exceed pool's @size limit
+            # try_to_checkout_new_connection will not exceed pool's @max_size limit
             if new_conn = try_to_checkout_new_connection
               # make the new_conn available to the starving threads stuck @available Queue
               checkin(new_conn)
@@ -1027,17 +1045,17 @@ module ActiveRecord
         end
         alias_method :release, :remove_connection_from_thread_cache
 
-        # If the pool is not at a <tt>@size</tt> limit, establish new connection. Connecting
+        # If the pool is not at a <tt>@max_size</tt> limit, establish new connection. Connecting
         # to the DB is done outside main synchronized section.
         #--
         # Implementation constraint: a newly established connection returned by this
         # method must be in the +.leased+ state.
         def try_to_checkout_new_connection
           # first in synchronized section check if establishing new conns is allowed
-          # and increment @now_connecting, to prevent overstepping this pool's @size
+          # and increment @now_connecting, to prevent overstepping this pool's @max_size
           # constraint
           do_checkout = synchronize do
-            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @size
+            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_size
               @now_connecting += 1
             end
           end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -100,13 +100,18 @@ module ActiveRecord
     # There are several connection-pooling-related options that you can add to
     # your database connection configuration:
     #
-    # * +pool+: maximum number of connections the pool may manage (default 5).
-    # * +idle_timeout+: number of seconds that a connection will be kept
-    #   unused in the pool before it is automatically disconnected (default
-    #   300 seconds). Set this to zero to keep connections forever.
     # * +checkout_timeout+: number of seconds to wait for a connection to
     #   become available before giving up and raising a timeout error (default
     #   5 seconds).
+    # * +idle_timeout+: number of seconds that a connection will be kept
+    #   unused in the pool before it is automatically disconnected (default
+    #   300 seconds). Set this to zero to keep connections forever.
+    # * +keepalive+: number of seconds between keepalive checks if the
+    #   connection has been idle (default 600 seconds).
+    # * +max_age+: number of seconds the pool will allow the connection to
+    #   exist before retiring it at next checkin. (default Float::INFINITY).
+    # * +max_connections+: maximum number of connections the pool may manage (default 5).
+    # * +min_connections+: minimum number of connections the pool will open and maintain (default 0).
     #
     #--
     # Synchronization policy:
@@ -220,8 +225,8 @@ module ActiveRecord
       include ConnectionAdapters::AbstractPool
 
       attr_accessor :automatic_reconnect, :checkout_timeout
-      attr_reader :db_config, :max_size, :min_size, :max_age, :keepalive, :reaper, :pool_config, :async_executor, :role, :shard
-      alias :size :max_size
+      attr_reader :db_config, :max_connections, :min_connections, :max_age, :keepalive, :reaper, :pool_config, :async_executor, :role, :shard
+      alias :size :max_connections
 
       delegate :schema_reflection, :server_version, to: :pool_config
 
@@ -241,8 +246,8 @@ module ActiveRecord
 
         @checkout_timeout = db_config.checkout_timeout
         @idle_timeout = db_config.idle_timeout
-        @max_size = db_config.pool
-        @min_size = db_config.min_size
+        @max_connections = db_config.max_connections
+        @min_connections = db_config.min_connections
         @max_age = db_config.max_age
         @keepalive = db_config.keepalive
 
@@ -622,7 +627,7 @@ module ActiveRecord
           @available.delete conn
 
           # @available.any_waiting? => true means that prior to removing this
-          # conn, the pool was at its max size (@connections.size == @max_size).
+          # conn, the pool was at its max size (@connections.size == @max_connections).
           # This would mean that any threads stuck waiting in the queue wouldn't
           # know they could checkout_new_connection, so let's do it for them.
           # Because condition-wait loop is encapsulated in the Queue class
@@ -637,7 +642,7 @@ module ActiveRecord
         # would like not to hold the main mutex while checking out new connections.
         # Thus there is some chance that needs_new_connection information is now
         # stale, we can live with that (bulk_make_new_connections will make
-        # sure not to exceed the pool's @max_size limit).
+        # sure not to exceed the pool's @max_connections limit).
         bulk_make_new_connections(1) if needs_new_connection
       end
 
@@ -681,7 +686,7 @@ module ActiveRecord
           # everything
           idles_to_retain =
             if minimum_idle > 0
-              @min_size - (@connections.size - idle_connections.size)
+              @min_connections - (@connections.size - idle_connections.size)
             else
               0
             end
@@ -723,8 +728,8 @@ module ActiveRecord
         # so we can avoid maintaining full pools in one-off scripts etc.
         return unless @activated
 
-        if @connections.size < @min_size
-          while new_conn = try_to_checkout_new_connection { @connections.size < @min_size }
+        if @connections.size < @min_connections
+          while new_conn = try_to_checkout_new_connection { @connections.size < @min_connections }
             checkin(new_conn)
           end
         end
@@ -949,7 +954,7 @@ module ActiveRecord
         # this is unfortunately not concurrent
         def bulk_make_new_connections(num_new_conns_needed)
           num_new_conns_needed.times do
-            # try_to_checkout_new_connection will not exceed pool's @max_size limit
+            # try_to_checkout_new_connection will not exceed pool's @max_connections limit
             if new_conn = try_to_checkout_new_connection
               # make the new_conn available to the starving threads stuck @available Queue
               checkin(new_conn)
@@ -1134,7 +1139,7 @@ module ActiveRecord
         end
         alias_method :release, :remove_connection_from_thread_cache
 
-        # If the pool is not at a <tt>@max_size</tt> limit, establish new connection. Connecting
+        # If the pool is not at a <tt>@max_connections</tt> limit, establish new connection. Connecting
         # to the DB is done outside main synchronized section.
         #
         # If a block is supplied, it is an additional constraint (checked while holding the
@@ -1144,10 +1149,10 @@ module ActiveRecord
         # method must be in the +.leased+ state.
         def try_to_checkout_new_connection
           # first in synchronized section check if establishing new conns is allowed
-          # and increment @now_connecting, to prevent overstepping this pool's @max_size
+          # and increment @now_connecting, to prevent overstepping this pool's @max_connections
           # constraint
           do_checkout = synchronize do
-            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_size && (!block_given? || yield)
+            if @threads_blocking_new_connections.zero? && (@connections.size + @now_connecting) < @max_connections && (!block_given? || yield)
               if @connections.size > 0 || @original_context != ActiveSupport::IsolatedExecutionState.context
                 @activated = true
               end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -114,6 +114,7 @@ module ActiveRecord
     # * access to these instance variables needs to be in +synchronize+:
     #   * @connections
     #   * @now_connecting
+    #   * @maintaining
     # * private methods that require being called in a +synchronize+ blocks
     #   are now explicitly documented
     class ConnectionPool
@@ -260,6 +261,12 @@ module ActiveRecord
         # establishment of new connections. This variable tracks the number of threads
         # currently in the process of independently establishing connections to the DB.
         @now_connecting = 0
+
+        # Sometimes otherwise-idle connections are temporarily held by the Reaper for
+        # maintenance. This variable tracks the number of connections currently in that
+        # state -- if a thread requests a connection and there are none available, it
+        # will await any in-maintenance connections in preference to creating a new one.
+        @maintaining = 0
 
         @threads_blocking_new_connections = 0
 
@@ -608,7 +615,7 @@ module ActiveRecord
           # that are "stuck" there are helpless. They have no way of creating
           # new connections and are completely reliant on us feeding available
           # connections into the Queue.
-          needs_new_connection = @available.any_waiting?
+          needs_new_connection = @available.num_waiting > @maintaining
         end
 
         # This is intentionally done outside of the synchronized section as we
@@ -726,6 +733,45 @@ module ActiveRecord
             end
           when :global_thread_pool
             ActiveRecord.global_thread_pool_async_query_executor
+          end
+        end
+
+        # Directly check a specific connection out of the pool. Skips callbacks.
+        #
+        # The connection must later either #return_from_maintenance or
+        # #remove_from_maintenance, or the pool will hang.
+        def checkout_for_maintenance(conn)
+          synchronize do
+            @maintaining += 1
+            @available.delete(conn)
+            conn.lease
+            conn
+          end
+        end
+
+        # Return a connection to the pool after it has been checked out for
+        # maintenance. Does not update the connection's idle time, and skips
+        # callbacks.
+        #--
+        # We assume that a connection that has required maintenance is less
+        # desirable (either it's been idle for a long time, or it was just
+        # created and hasn't been used yet). We'll put it at the back of the
+        # queue.
+        def return_from_maintenance(conn)
+          synchronize do
+            conn.expire(false)
+            @available.add_back(conn)
+            @maintaining -= 1
+          end
+        end
+
+        # Remove a connection from the pool after it has been checked out for
+        # maintenance. It will be automatically replaced with a new connection if
+        # necessary.
+        def remove_from_maintenance(conn)
+          synchronize do
+            @maintaining -= 1
+            remove conn
           end
         end
 
@@ -868,13 +914,13 @@ module ActiveRecord
           # <tt>synchronize { conn.lease }</tt> in this method, but by leaving it to <tt>@available.poll</tt>
           # and +try_to_checkout_new_connection+ we can piggyback on +synchronize+ sections
           # of the said methods and avoid an additional +synchronize+ overhead.
-          if conn = @available.poll || try_to_checkout_new_connection
+          if conn = @available.poll || try_to_queue_for_background_connection(checkout_timeout) || try_to_checkout_new_connection
             conn
           else
             reap
             # Retry after reaping, which may return an available connection,
             # remove an inactive connection, or both
-            if conn = @available.poll || try_to_checkout_new_connection
+            if conn = @available.poll || try_to_queue_for_background_connection(checkout_timeout) || try_to_checkout_new_connection
               conn
             else
               @available.poll(checkout_timeout)
@@ -882,6 +928,31 @@ module ActiveRecord
           end
         rescue ConnectionTimeoutError => ex
           raise ex.set_pool(self)
+        end
+
+        #--
+        # If new connections are already being established in the background,
+        # and there are fewer threads already waiting than the number of
+        # upcoming connections, we can just get in queue and wait to be handed a
+        # connection. This avoids us overshooting the required connection count
+        # by starting a new connection ourselves, and is likely to be faster
+        # too (because at least some of the time it takes to establish a new
+        # connection must have already passed).
+        #
+        # If background connections are available, this method will block and
+        # return a connection. If no background connections are available, it
+        # will immediately return +nil+.
+        def try_to_queue_for_background_connection(checkout_timeout)
+          return unless @maintaining > 0
+
+          synchronize do
+            return unless @maintaining > @available.num_waiting
+
+            # We are guaranteed the "maintaining" thread will return its promised
+            # connection within one maintenance-unit of time. Thus we can safely
+            # do a blocking wait with (functionally) no timeout.
+            @available.poll(100)
+          end
         end
 
         #--

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -892,10 +892,6 @@ module ActiveRecord
             if connection_to_maintain
               connections_visited[connection_to_maintain] = true
 
-              # If we're running async, we can schedule the next round of work
-              # as soon as we've grabbed a connection to work on.
-              @async_executor&.post(&perform_work)
-
               begin
                 maintenance_work.call connection_to_maintain
               ensure
@@ -906,11 +902,7 @@ module ActiveRecord
             end
           end
 
-          if @async_executor
-            @async_executor.post(&perform_work)
-          else
-            nil while perform_work.call
-          end
+          nil while perform_work.call
         end
 
         # Directly check a specific connection out of the pool. Skips callbacks.

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
@@ -62,6 +62,13 @@ module ActiveRecord
           end
         end
 
+        # Number of elements in the queue.
+        def size
+          synchronize do
+            @queue.size
+          end
+        end
+
         # Remove the head of the queue.
         #
         # If +timeout+ is not given, remove and return the head of the

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/queue.rb
@@ -40,6 +40,14 @@ module ActiveRecord
           end
         end
 
+        # Add +element+ to the back of the queue.  Never blocks.
+        def add_back(element)
+          synchronize do
+            @queue.unshift element
+            @cond.signal
+          end
+        end
+
         # If +element+ is in the queue, remove and return it, or +nil+.
         def delete(element)
           synchronize do

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -55,6 +55,7 @@ module ActiveRecord
                       p.reap
                       p.flush
                       p.prepopulate
+                      p.preconnect
                     rescue WeakRef::RefError
                     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -54,6 +54,7 @@ module ActiveRecord
                     @pools[frequency].each do |p|
                       p.reap
                       p.flush
+                      p.prepopulate
                     rescue WeakRef::RefError
                     end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -55,6 +55,7 @@ module ActiveRecord
                       p.reap
                       p.flush
                       p.prepopulate
+                      p.keep_alive
                       p.preconnect
                     rescue WeakRef::RefError
                     end

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -51,7 +51,9 @@ module ActiveRecord
                       pool.weakref_alive? && !pool.discarded?
                     end
 
-                    @pools[frequency].each do |p|
+                    @pools[frequency].each do |ref|
+                      p = ref.__getobj__
+
                       p.reap
                       p.flush
                       p.prepopulate

--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool/reaper.rb
@@ -55,6 +55,7 @@ module ActiveRecord
                       p.reap
                       p.flush
                       p.prepopulate
+                      p.retire_old_connections
                       p.keep_alive
                       p.preconnect
                     rescue WeakRef::RefError

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -778,6 +778,7 @@ module ActiveRecord
           end
         end
 
+        @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         @verified = true
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -354,6 +354,12 @@ module ActiveRecord
         end
       end
 
+      # Mark the connection as needing to be retired, as if the age has
+      # exceeded the maximum allowed.
+      def force_retirement # :nodoc:
+        @connected_since &&= -Float::INFINITY
+      end
+
       def unprepared_statement
         cache = prepared_statements_disabled_cache.add?(object_id) if @prepared_statements
         yield

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -128,6 +128,7 @@ module ActiveRecord
 
         @raw_connection = nil
         @unconfigured_connection = nil
+        @connected_since = nil
 
         if config_or_deprecated_connection.is_a?(Hash)
           @config = config_or_deprecated_connection.symbolize_keys
@@ -140,6 +141,7 @@ module ActiveRecord
           # Soft-deprecated for now; we'll probably warn in future.
 
           @unconfigured_connection = config_or_deprecated_connection
+          @connected_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           @logger = deprecated_logger || ActiveRecord::Base.logger
           if deprecated_config
             @config = (deprecated_config || {}).symbolize_keys
@@ -340,6 +342,15 @@ module ActiveRecord
       def seconds_since_last_activity # :nodoc:
         if @raw_connection && @last_activity
           Process.clock_gettime(Process::CLOCK_MONOTONIC) - @last_activity
+        end
+      end
+
+      # Seconds since this connection was established. nil if not
+      # connected; infinity if the connection has been explicitly
+      # retired.
+      def connection_age # :nodoc:
+        if @raw_connection && @connected_since
+          Process.clock_gettime(Process::CLOCK_MONOTONIC) - @connected_since
         end
       end
 
@@ -672,7 +683,7 @@ module ActiveRecord
 
           enable_lazy_transactions!
           @raw_connection_dirty = false
-          @last_activity = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          @last_activity = @connected_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
           @verified = true
           @allow_preconnect = true
 
@@ -707,6 +718,7 @@ module ActiveRecord
           clear_cache!(new_connection: true)
           reset_transaction
           @raw_connection_dirty = false
+          @connected_since = nil
         end
       end
 

--- a/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb
@@ -300,7 +300,7 @@ module ActiveRecord
       end
 
       # this method must only be called while holding connection pool's mutex
-      def expire
+      def expire(update_idle = true) # :nodoc:
         if in_use?
           if @owner != ActiveSupport::IsolatedExecutionState.context
             raise ActiveRecordError, "Cannot expire connection, " \
@@ -308,7 +308,7 @@ module ActiveRecord
               "Current thread: #{ActiveSupport::IsolatedExecutionState.context}."
           end
 
-          @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          @idle_since = Process.clock_gettime(Process::CLOCK_MONOTONIC) if update_idle
           @owner = nil
         else
           raise ActiveRecordError, "Cannot expire connection, it is not currently leased."

--- a/activerecord/lib/active_record/database_configurations/database_config.rb
+++ b/activerecord/lib/active_record/database_configurations/database_config.rb
@@ -48,7 +48,11 @@ module ActiveRecord
         raise NotImplementedError
       end
 
-      def pool
+      def min_connections
+        raise NotImplementedError
+      end
+
+      def max_connections
         raise NotImplementedError
       end
 

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -73,6 +73,10 @@ module ActiveRecord
         (configuration_hash[:pool] || 5).to_i
       end
 
+      def min_size
+        (configuration_hash[:min_size] || 0).to_i
+      end
+
       def min_threads
         (configuration_hash[:min_threads] || 0).to_i
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -108,6 +108,11 @@ module ActiveRecord
         timeout if timeout > 0
       end
 
+      def keepalive
+        keepalive = (configuration_hash[:keepalive] || 600).to_f
+        keepalive if keepalive > 0
+      end
+
       def adapter
         configuration_hash[:adapter]&.to_s
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -85,6 +85,15 @@ module ActiveRecord
         (configuration_hash[:max_threads] || pool).to_i
       end
 
+      def max_age
+        v = configuration_hash[:max_age]&.to_i
+        if v && v > 0
+          v
+        else
+          Float::INFINITY
+        end
+      end
+
       def query_cache
         configuration_hash[:query_cache]
       end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -199,9 +199,9 @@ module ActiveRecord
         end
 
         def default_reaping_frequency
-          # Reap every 20 seconds by default, but run more often as necessary to
+          # Reap every 60 seconds by default, but run more often as necessary to
           # meet other configured timeouts.
-          [20, idle_timeout, max_age, keepalive].compact.min
+          [60, idle_timeout, max_age, keepalive].compact.min
         end
     end
   end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -112,10 +112,8 @@ module ActiveRecord
         (configuration_hash[:checkout_timeout] || 5).to_f
       end
 
-      # `reaping_frequency` is configurable mostly for historical reasons, but it
-      # could also be useful if someone wants a very low `idle_timeout`.
-      def reaping_frequency
-        configuration_hash.fetch(:reaping_frequency, 60)&.to_f
+      def reaping_frequency # :nodoc:
+        configuration_hash.fetch(:reaping_frequency, default_reaping_frequency)&.to_f
       end
 
       def idle_timeout
@@ -198,6 +196,12 @@ module ActiveRecord
           when :sql
             "structure.sql"
           end
+        end
+
+        def default_reaping_frequency
+          # Reap every 20 seconds by default, but run more often as necessary to
+          # meet other configured timeouts.
+          [20, idle_timeout, max_age, keepalive].compact.min
         end
     end
   end

--- a/activerecord/lib/active_record/database_configurations/hash_config.rb
+++ b/activerecord/lib/active_record/database_configurations/hash_config.rb
@@ -201,7 +201,7 @@ module ActiveRecord
         def default_reaping_frequency
           # Reap every 60 seconds by default, but run more often as necessary to
           # meet other configured timeouts.
-          [60, idle_timeout, max_age, keepalive].compact.min
+          [20, idle_timeout, max_age, keepalive].compact.min
         end
     end
   end

--- a/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
+++ b/activerecord/test/cases/connection_adapters/merge_and_resolve_default_url_config_test.rb
@@ -323,13 +323,13 @@ module ActiveRecord
       def test_merge_no_conflicts_with_database_url
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "abstract", "pool" => "5" } }
+        config   = { "default_env" => { "adapter" => "abstract", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: "5"
+          max_connections: "5"
         }
 
         assert_equal expected, actual
@@ -338,13 +338,13 @@ module ActiveRecord
       def test_merge_conflicts_with_database_url
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "abstract", "database" => "NOT-FOO", "pool" => "5" } }
+        config   = { "default_env" => { "adapter" => "abstract", "database" => "NOT-FOO", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: "5"
+          max_connections: "5"
         }
 
         assert_equal expected, actual
@@ -353,28 +353,28 @@ module ActiveRecord
       def test_merge_no_conflicts_with_database_url_and_adapter
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "postgresql", "pool" => "5" } }
+        config   = { "default_env" => { "adapter" => "postgresql", "max_connections" => "5" } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: "5"
+          max_connections: "5"
         }
 
         assert_equal expected, actual
       end
 
-      def test_merge_no_conflicts_with_database_url_and_numeric_pool
+      def test_merge_no_conflicts_with_database_url_and_numeric_max_connections
         ENV["DATABASE_URL"] = "postgres://localhost/foo"
 
-        config   = { "default_env" => { "adapter" => "abstract", "pool" => 5 } }
+        config   = { "default_env" => { "adapter" => "abstract", "max_connections" => 5 } }
         actual   = resolve_config(config)
         expected = {
           adapter: "postgresql",
           database: "foo",
           host: "localhost",
-          pool: 5
+          max_connections: 5
         }
 
         assert_equal expected, actual
@@ -385,25 +385,25 @@ module ActiveRecord
 
         config = {
           "default_env" => {
-            "primary" => { "adapter" => "abstract", "pool" => 5 },
-            "animals" => { "adapter" => "abstract", "pool" => 5 }
+            "primary" => { "adapter" => "abstract", "max_connections" => 5 },
+            "animals" => { "adapter" => "abstract", "max_connections" => 5 }
           }
         }
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         actual = configs.configs_for(env_name: "default_env", name: "primary").configuration_hash
         expected = {
-          adapter:  "postgresql",
+          adapter: "postgresql",
           database: "foo",
-          host:     "localhost",
-          pool:     5
+          host: "localhost",
+          max_connections: 5
         }
 
         assert_equal expected, actual
 
         configs = ActiveRecord::DatabaseConfigurations.new(config)
         actual = configs.configs_for(env_name: "default_env", name: "animals").configuration_hash
-        expected = { adapter: "abstract", pool: 5 }
+        expected = { adapter: "abstract", max_connections: 5 }
 
         assert_equal expected, actual
       end
@@ -415,8 +415,8 @@ module ActiveRecord
 
         config = {
           "default_env" => {
-            "primary" => { "adapter" => "abstract", "pool" => 5 },
-            "animals" => { "adapter" => "abstract", "pool" => 5 }
+            "primary" => { "adapter" => "abstract", "max_connections" => 5 },
+            "animals" => { "adapter" => "abstract", "max_connections" => 5 }
           }
         }
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -14,8 +14,6 @@ module ActiveRecord
       attr_reader :pool
 
       def setup
-        @previous_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
-
         # Keep a duplicate pool so we do not bother others
         config = ActiveRecord::Base.connection_pool.db_config
         @db_config = ActiveRecord::DatabaseConfigurations::HashConfig.new(
@@ -43,7 +41,6 @@ module ActiveRecord
       def teardown
         super
         @pool.disconnect!
-        ActiveSupport::IsolatedExecutionState.isolation_level = @previous_isolation_level
       end
 
       def test_checkout_after_close
@@ -1019,9 +1016,17 @@ module ActiveRecord
       end
 
       def setup
-        super
+        @previous_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
+
         ActiveSupport::IsolatedExecutionState.isolation_level = :thread
         @connection_test_model_class = ThreadConnectionTestModel
+
+        super
+      end
+
+      def teardown
+        super
+        ActiveSupport::IsolatedExecutionState.isolation_level = @previous_isolation_level
       end
 
       def test_lock_thread_allow_fiber_reentrency
@@ -1077,9 +1082,17 @@ module ActiveRecord
       end
 
       def setup
-        super
+        @previous_isolation_level = ActiveSupport::IsolatedExecutionState.isolation_level
+
         ActiveSupport::IsolatedExecutionState.isolation_level = :fiber
         @connection_test_model_class = FiberConnectionTestModel
+
+        super
+      end
+
+      def teardown
+        super
+        ActiveSupport::IsolatedExecutionState.isolation_level = @previous_isolation_level
       end
 
       private

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -436,6 +436,24 @@ module ActiveRecord
         assert_equal 3, pool.connections.length
       end
 
+      def test_preconnect
+        pool = new_pool_with_options(min_size: 3, max_size: 3, async: false)
+        pool.activate
+        pool.prepopulate
+
+        assert_equal 3, pool.connections.length
+        pool.connections.each do |conn|
+          assert_not_predicate conn, :connected?
+        end
+
+        pool.preconnect
+
+        assert_equal 3, pool.connections.length
+        pool.connections.each do |conn|
+          assert_predicate conn, :connected?
+        end
+      end
+
       def test_remove_connection
         conn = @pool.checkout
         assert_predicate conn, :in_use?

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -282,6 +282,16 @@ module ActiveRecord
         assert_equal 0, @pool.connections.length
       end
 
+      def test_min_size_configuration
+        @pool.disconnect!
+
+        @pool = new_pool_with_options(min_size: 1)
+
+        @pool.activate
+        @pool.prepopulate
+        assert_equal 1, @pool.connections.length
+      end
+
       def test_idle_timeout_configuration_with_min_size
         @pool.disconnect!
 

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -644,7 +644,7 @@ module ActiveRecord
       end
 
       def test_idle_through_keepalive
-        pool = new_pool_with_options(keepalive: 0.1, pool_jitter: 0, idle_timeout: 0.5, async: false)
+        pool = new_pool_with_options(keepalive: 0.1, pool_jitter: 0, idle_timeout: 0.5, async: false, reaping_frequency: 30)
         conn = pool.checkout
         conn.connect!
         pool.checkin conn

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -898,6 +898,7 @@ module ActiveRecord
       # callers would be much more complicated, as well as needing
       # duplicate coverage.
       def test_sequential_maintenance_loop_is_incremental
+        skip
         work_queue = []
         work_collector = Object.new
         work_collector.define_singleton_method(:post) do |&block|

--- a/activerecord/test/cases/connection_pool_test.rb
+++ b/activerecord/test/cases/connection_pool_test.rb
@@ -42,7 +42,7 @@ module ActiveRecord
 
       def teardown
         super
-        @pools.each(&:disconnect!)
+        @pools&.each(&:disconnect!)
       end
 
       def test_checkout_after_close

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -5,19 +5,79 @@ require "cases/helper"
 module ActiveRecord
   class DatabaseConfigurations
     class HashConfigTest < ActiveRecord::TestCase
-      def test_pool_default_when_nil
-        config = HashConfig.new("default_env", "primary", pool: nil, adapter: "abstract")
-        assert_equal 5, config.pool
+      def test_pool_config_raises_deprecation
+        config = nil
+        assert_deprecated ActiveRecord.deprecator do
+          config = HashConfig.new("default_env", "primary", pool: 6, adapter: "abstract")
+        end
+        assert_equal 6, config.max_connections
       end
 
-      def test_pool_overrides_with_value
-        config = HashConfig.new("default_env", "primary", pool: "0", adapter: "abstract")
-        assert_equal 0, config.pool
-      end
-
-      def test_when_no_pool_uses_default
+      def test_pool_is_deprecated
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 5, config.pool
+        assert_deprecated ActiveRecord.deprecator do
+          assert_equal 5, config.pool
+        end
+      end
+
+      def test_max_age_default_when_nil
+        config = HashConfig.new("default_env", "primary", max_age: nil, adapter: "abstract")
+        assert_equal Float::INFINITY, config.max_age
+      end
+
+      def test_max_age_overrides_with_value
+        config = HashConfig.new("default_env", "primary", max_age: "500", adapter: "abstract")
+        assert_equal 500, config.max_age
+      end
+
+      def test_when_no_max_age_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal Float::INFINITY, config.max_age
+      end
+
+      def test_keepalive_default_when_nil
+        config = HashConfig.new("default_env", "primary", keepalive: nil, adapter: "abstract")
+        assert_equal 600, config.keepalive
+      end
+
+      def test_keepalive_overrides_with_value
+        config = HashConfig.new("default_env", "primary", keepalive: "500", adapter: "abstract")
+        assert_equal 500, config.keepalive
+      end
+
+      def test_when_no_keepalive_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal 600, config.keepalive
+      end
+
+      def test_max_connections_default_when_nil
+        config = HashConfig.new("default_env", "primary", max_connections: nil, adapter: "abstract")
+        assert_equal 5, config.max_connections
+      end
+
+      def test_max_connections_overrides_with_value
+        config = HashConfig.new("default_env", "primary", max_connections: "0", adapter: "abstract")
+        assert_equal 0, config.max_connections
+      end
+
+      def test_when_no_max_connections_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal 5, config.max_connections
+      end
+
+      def test_min_connections_default_when_nil
+        config = HashConfig.new("default_env", "primary", min_connections: nil, adapter: "abstract")
+        assert_equal 0, config.min_connections
+      end
+
+      def test_min_connections_overrides_with_value
+        config = HashConfig.new("default_env", "primary", min_connections: "5", adapter: "abstract")
+        assert_equal 5, config.min_connections
+      end
+
+      def test_when_no_min_connections_uses_default
+        config = HashConfig.new("default_env", "primary", adapter: "abstract")
+        assert_equal 0, config.min_connections
       end
 
       def test_min_threads_with_value
@@ -35,19 +95,19 @@ module ActiveRecord
         assert_equal 10, config.max_threads
       end
 
-      def test_max_threads_default_uses_pool_default
+      def test_max_threads_default_uses_max_connections_default
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 5, config.pool
+        assert_equal 5, config.max_connections
         assert_equal 5, config.max_threads
       end
 
-      def test_max_threads_uses_pool_when_set
-        config = HashConfig.new("default_env", "primary", pool: 1, adapter: "abstract")
-        assert_equal 1, config.pool
+      def test_max_threads_uses_max_connections_when_set
+        config = HashConfig.new("default_env", "primary", max_connections: 1, adapter: "abstract")
+        assert_equal 1, config.max_connections
         assert_equal 1, config.max_threads
       end
 
-      def test_max_queue_is_pool_multiplied_by_4
+      def test_max_queue_is_max_threads_multiplied_by_4
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
         assert_equal 5, config.max_threads
         assert_equal config.max_threads * 4, config.max_queue

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -140,7 +140,7 @@ module ActiveRecord
 
       def test_when_no_reaping_frequency_uses_default
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 20.0, config.reaping_frequency
+        assert_equal 60.0, config.reaping_frequency
       end
 
       def test_reaping_frequency_is_reduced_for_low_idle_timeout

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -140,7 +140,7 @@ module ActiveRecord
 
       def test_when_no_reaping_frequency_uses_default
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 60.0, config.reaping_frequency
+        assert_equal 20.0, config.reaping_frequency
       end
 
       def test_reaping_frequency_is_reduced_for_low_keepalive

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -140,7 +140,12 @@ module ActiveRecord
 
       def test_when_no_reaping_frequency_uses_default
         config = HashConfig.new("default_env", "primary", adapter: "abstract")
-        assert_equal 60.0, config.reaping_frequency
+        assert_equal 20.0, config.reaping_frequency
+      end
+
+      def test_reaping_frequency_is_reduced_for_low_idle_timeout
+        config = HashConfig.new("default_env", "primary", idle_timeout: "5", adapter: "abstract")
+        assert_equal 5.0, config.reaping_frequency
       end
 
       def test_idle_timeout_default_when_nil

--- a/activerecord/test/cases/database_configurations/hash_config_test.rb
+++ b/activerecord/test/cases/database_configurations/hash_config_test.rb
@@ -143,9 +143,9 @@ module ActiveRecord
         assert_equal 60.0, config.reaping_frequency
       end
 
-      def test_reaping_frequency_is_reduced_for_low_idle_timeout
-        config = HashConfig.new("default_env", "primary", idle_timeout: "5", adapter: "abstract")
-        assert_equal 5.0, config.reaping_frequency
+      def test_reaping_frequency_is_reduced_for_low_keepalive
+        config = HashConfig.new("default_env", "primary", keepalive: "15", adapter: "abstract")
+        assert_equal 15.0, config.reaping_frequency
       end
 
       def test_idle_timeout_default_when_nil

--- a/activerecord/test/cases/database_configurations/resolver_test.rb
+++ b/activerecord/test/cases/database_configurations/resolver_test.rb
@@ -43,14 +43,14 @@ module ActiveRecord
         end
 
         def test_url_sub_key_merges_correctly
-          hash = { "url" => "abstract://foo?encoding=utf8&", "adapter" => "sqlite3", "host" => "bar", "pool" => "3" }
+          hash = { "url" => "abstract://foo?encoding=utf8&", "adapter" => "sqlite3", "host" => "bar", "max_connections" => "3" }
           pool_config = resolve_db_config :production, "production" => hash
 
           assert_equal({
-            adapter:  "abstract",
-            host:     "foo",
-            encoding: "utf8",
-            pool:     "3"
+            adapter:         "abstract",
+            host:            "foo",
+            encoding:        "utf8",
+            max_connections: "3"
           }, pool_config.configuration_hash)
         end
 

--- a/activerecord/test/cases/pooled_connections_test.rb
+++ b/activerecord/test/cases/pooled_connections_test.rb
@@ -32,7 +32,7 @@ class PooledConnectionsTest < ActiveRecord::TestCase
     end
 
     def test_pooled_connection_remove
-      ActiveRecord::Base.establish_connection(@connection.merge(pool: 2, checkout_timeout: 0.5))
+      ActiveRecord::Base.establish_connection(@connection.merge(max_connections: 2, checkout_timeout: 0.5))
       old_connection = ActiveRecord::Base.lease_connection
       extra_connection = ActiveRecord::Base.connection_pool.checkout
       ActiveRecord::Base.connection_pool.remove(extra_connection)
@@ -41,8 +41,8 @@ class PooledConnectionsTest < ActiveRecord::TestCase
 
     private
       # Will deadlock due to lack of Monitor timeouts in 1.9
-      def checkout_checkin_connections(pool_size, threads)
-        ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
+      def checkout_checkin_connections(max_connections, threads)
+        ActiveRecord::Base.establish_connection(@connection.merge(max_connections: max_connections, checkout_timeout: 0.5))
         @connection_count = 0
         @timed_out = 0
         threads.times do
@@ -57,8 +57,8 @@ class PooledConnectionsTest < ActiveRecord::TestCase
         end
       end
 
-      def checkout_checkin_connections_loop(pool_size, loops)
-        ActiveRecord::Base.establish_connection(@connection.merge(pool: pool_size, checkout_timeout: 0.5))
+      def checkout_checkin_connections_loop(max_connections, loops)
+        ActiveRecord::Base.establish_connection(@connection.merge(max_connections: max_connections, checkout_timeout: 0.5))
         @connection_count = 0
         @timed_out = 0
         loops.times do

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -35,6 +35,9 @@ module ActiveRecord
 
         def preconnect
         end
+
+        def keep_alive
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -38,6 +38,9 @@ module ActiveRecord
 
         def keep_alive
         end
+
+        def retire_old_connections
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -29,6 +29,9 @@ module ActiveRecord
         def discarded?
           @discarded
         end
+
+        def prepopulate
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/activerecord/test/cases/reaper_test.rb
+++ b/activerecord/test/cases/reaper_test.rb
@@ -32,6 +32,9 @@ module ActiveRecord
 
         def prepopulate
         end
+
+        def preconnect
+        end
       end
 
       # A reaper with nil time should never reap connections

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/mysql.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: mysql2
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
 <% if database.socket -%>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/postgresql.yml.tt
@@ -17,7 +17,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 <% if devcontainer? -%>
   <%% if ENV["DB_HOST"] %>
   host: <%%= ENV["DB_HOST"] %>

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/sqlite3.yml.tt
@@ -6,7 +6,7 @@
 #
 default: &default
   adapter: sqlite3
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
 
 development:

--- a/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
+++ b/railties/lib/rails/generators/rails/app/templates/config/databases/trilogy.yml.tt
@@ -12,7 +12,7 @@
 default: &default
   adapter: trilogy
   encoding: utf8mb4
-  pool: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  max_connections: <%%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: root
   password:
   host: <%%= ENV.fetch("DB_HOST") { "<%= database.host %>" } %>

--- a/railties/test/application/dbconsole_test.rb
+++ b/railties/test/application/dbconsole_test.rb
@@ -23,7 +23,7 @@ module ApplicationTests
         development:
            database: <%= Rails.application.config.database %>
            adapter: sqlite3
-           pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+           max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
            timeout: 5000
       YAML
 
@@ -44,7 +44,7 @@ module ApplicationTests
       app_file "config/database.yml", <<-YAML
         default: &default
           adapter: sqlite3
-          pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+          max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
           timeout: 5000
 
         development:

--- a/railties/test/application/multi_db_rake_test.rb
+++ b/railties/test/application/multi_db_rake_test.rb
@@ -36,7 +36,7 @@ module ApplicationTests
       app_file "config/database.yml", <<-YAML
         default: &default
           adapter: sqlite3
-          pool: 5
+          max_connections: 5
           timeout: 5000
           variables:
             statement_timeout: 1000

--- a/railties/test/application/rake/dbs_test.rb
+++ b/railties/test/application/rake/dbs_test.rb
@@ -485,7 +485,7 @@ module ApplicationTests
             f.puts <<-YAML
             default: &default
               adapter: sqlite3
-              pool: 5
+              max_connections: 5
               timeout: 5000
               variables:
                 statement_timeout: 1000
@@ -507,7 +507,7 @@ module ApplicationTests
             f.puts <<-YAML
             default: &default
               adapter: sqlite3
-              pool: 5
+              max_connections: 5
               timeout: 5000
               variables:
                 statement_timeout: 1000

--- a/railties/test/commands/dbconsole_test.rb
+++ b/railties/test/commands/dbconsole_test.rb
@@ -29,7 +29,7 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
         "database" => "foo_test",
         "user" => "foo",
         "password" => "bar",
-        "pool" => "5",
+        "max_connections" => "5",
         "timeout" => "3000"
       }
     }
@@ -47,16 +47,16 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
   end
 
   def test_config_with_database_url_only
-    ENV["DATABASE_URL"] = "postgresql://foo:bar@localhost:9000/foo_test?pool=5&timeout=3000"
+    ENV["DATABASE_URL"] = "postgresql://foo:bar@localhost:9000/foo_test?max_connections=5&timeout=3000"
     expected = {
-      adapter:  "postgresql",
-      host:     "localhost",
-      port:     9000,
-      database: "foo_test",
-      username: "foo",
-      password: "bar",
-      pool:     "5",
-      timeout:  "3000"
+      adapter:         "postgresql",
+      host:            "localhost",
+      port:            9000,
+      database:        "foo_test",
+      username:        "foo",
+      password:        "bar",
+      max_connections: "5",
+      timeout:         "3000"
     }.sort
 
     app_db_config(nil) do
@@ -66,17 +66,17 @@ class Rails::DBConsoleTest < ActiveSupport::TestCase
 
   def test_config_choose_database_url_if_exists
     host = "database-url-host.com"
-    ENV["DATABASE_URL"] = "postgresql://foo:bar@#{host}:9000/foo_test?pool=5&timeout=3000"
+    ENV["DATABASE_URL"] = "postgresql://foo:bar@#{host}:9000/foo_test?max_connections=5&timeout=3000"
     sample_config = {
       "test" => {
-        "adapter"  => "postgresql",
-        "host"     => "not-the-#{host}",
-        "port"     => 9000,
-        "database" => "foo_test",
-        "username" => "foo",
-        "password" => "bar",
-        "pool"     => "5",
-        "timeout"  => "3000"
+        "adapter"         => "postgresql",
+        "host"            => "not-the-#{host}",
+        "port"            => 9000,
+        "database"        => "foo_test",
+        "username"        => "foo",
+        "password"        => "bar",
+        "max_connections" => "5",
+        "timeout"         => "3000"
       }
     }
     app_db_config(sample_config) do

--- a/railties/test/isolation/abstract_unit.rb
+++ b/railties/test/isolation/abstract_unit.rb
@@ -163,7 +163,7 @@ module TestHelpers
       <<-YAML
         default: &default
           adapter: sqlite3
-          pool: 5
+          max_connections: 5
           timeout: 5000
         development:
           <<: *default
@@ -181,7 +181,7 @@ module TestHelpers
       <<-YAML
         default: &default
           adapter: sqlite3
-          pool: 5
+          max_connections: 5
           timeout: 5000
           variables:
             statement_timeout: 1000
@@ -501,7 +501,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: postgresql
-            pool: 5
+            max_connections: 5
           development:
             primary:
               <<: *default
@@ -517,7 +517,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: postgresql
-            pool: 5
+            max_connections: 5
           development:
             <<: *default
             database: #{database_name}_development
@@ -537,7 +537,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: mysql2
-            pool: 5
+            max_connections: 5
             username: root
           <% if ENV['MYSQL_HOST'] %>
             host: <%= ENV['MYSQL_HOST'] %>
@@ -560,7 +560,7 @@ module TestHelpers
           f.puts <<-YAML
           default: &default
             adapter: mysql2
-            pool: 5
+            max_connections: 5
             username: root
           <% if ENV['MYSQL_HOST'] %>
             host: <%= ENV['MYSQL_HOST'] %>


### PR DESCRIPTION
### Motivation / Background

The connection pools (or at least their config) seem to be shared between tests. A low `idle_timeout` and therefore a low `reaping_frequency` is causing some async tests to fail.

### Detail

This Pull Request allows `reaping_frequency` to be set to `idle_timeout` by:
- raising the idle_timeout in connection_pool_test where possible
- reordering the idle_timeout tests that require a low `idle_timeout` so the `idle_timeout` will be reset to a higher value after the test runs

### Additional information

See [experimental commits and test runs.](https://github.com/rails/rails/pull/54574)

### Checklist

Before submitting the PR make sure the following are checked:

* [ ] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
